### PR TITLE
feat: add marble image generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "chanfana": "^2.6.3",
     "hono": "^4.6.20",
+    "pureimage": "^0.4.18",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       hono:
         specifier: ^4.6.20
         version: 4.9.5
+      pureimage:
+        specifier: ^0.4.18
+        version: 0.4.18
       zod:
         specifier: ^3.24.1
         version: 3.25.76
@@ -449,6 +452,9 @@ packages:
   is-arrayish@0.3.2:
     resolution: {integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==}
 
+  jpeg-js@0.4.4:
+    resolution: {integrity: sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==}
+
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -473,11 +479,23 @@ packages:
   openapi3-ts@4.5.0:
     resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
 
+  opentype.js@0.4.11:
+    resolution: {integrity: sha512-GthxucX/6aftfLdeU5Ho7o7zmQcC8uVtqdcelVq12X++ndxwBZG8Xb5rFEKT7nEcWDD2P1x+TNuJ70jtj1Mbpw==}
+    hasBin: true
+
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
+
+  pureimage@0.4.18:
+    resolution: {integrity: sha512-piyNT+J1bISJMHxz3VYUvgGLpQAa2NEt5nDdEIozO5Jhla0/jI/atSWFoRVTNrD5KosCMJSghohnqoIjWV0LEw==}
+    engines: {node: '>=14.19.0'}
 
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
@@ -869,6 +887,8 @@ snapshots:
 
   is-arrayish@0.3.2: {}
 
+  jpeg-js@0.4.4: {}
+
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
@@ -901,9 +921,19 @@ snapshots:
     dependencies:
       yaml: 2.8.1
 
+  opentype.js@0.4.11: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
+
+  pngjs@7.0.0: {}
+
+  pureimage@0.4.18:
+    dependencies:
+      jpeg-js: 0.4.4
+      opentype.js: 0.4.11
+      pngjs: 7.0.0
 
   semver@7.7.2: {}
 

--- a/src/endpoints/marbleImage.ts
+++ b/src/endpoints/marbleImage.ts
@@ -1,0 +1,112 @@
+import { OpenAPIRoute } from "chanfana";
+import { AppContext, MarbleQuery, ColorPreset } from "../types";
+import { z } from "zod";
+import * as PImage from "pureimage";
+import { PassThrough } from "stream";
+
+const colorPresets: Record<z.infer<typeof ColorPreset>, string[]> = {
+  blue: ["#1e3a8a", "#3b82f6", "#93c5fd"],
+  red: ["#7f1d1d", "#ef4444", "#fca5a5"],
+  green: ["#064e3b", "#10b981", "#6ee7b7"],
+  purple: ["#581c87", "#a855f7", "#d8b4fe"],
+};
+
+function xmur3(str: string) {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return function () {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    return (h ^= h >>> 16) >>> 0;
+  };
+}
+
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function getDimensions(size: string) {
+  switch (size) {
+    case "16:9":
+      return { width: 1600, height: 900 };
+    case "9:16":
+      return { width: 900, height: 1600 };
+    default:
+      return { width: 1000, height: 1000 };
+  }
+}
+
+export class MarbleImage extends OpenAPIRoute {
+  schema = {
+    summary: "Generate a marble pattern image",
+    request: {
+      query: MarbleQuery,
+    },
+    responses: {
+      200: {
+        description: "PNG marble image",
+        content: {
+          "image/png": {
+            schema: {
+              type: "string",
+              format: "binary",
+            },
+          },
+        },
+      },
+    },
+  } as const;
+
+  async handle(c: AppContext) {
+    const { query } = await this.getValidatedData<typeof this.schema>();
+    const { color, datetime, username, size } = query;
+
+    const ts = datetime ? new Date(datetime).getTime() : Date.now();
+    const seedStr = `${username ?? ""}${ts}`;
+    const seed = xmur3(seedStr)();
+    const rand = mulberry32(seed);
+
+    const { width, height } = getDimensions(size);
+    const img = PImage.make(width, height);
+    const ctx = img.getContext("2d");
+
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, width, height);
+
+    const palette = colorPresets[color];
+    for (let i = 0; i < 800; i++) {
+      ctx.fillStyle = palette[Math.floor(rand() * palette.length)];
+      const x = rand() * width;
+      const y = rand() * height;
+      const r = rand() * Math.min(width, height) * 0.1;
+      ctx.globalAlpha = 0.5;
+      ctx.beginPath();
+      ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.globalAlpha = 1;
+
+    const stream = new PassThrough();
+    const chunks: Buffer[] = [];
+    stream.on("data", (chunk) => chunks.push(chunk));
+    const pngPromise = PImage.encodePNGToStream(img, stream);
+    await pngPromise;
+    const buffer = Buffer.concat(chunks);
+    return new Response(buffer, {
+      headers: {
+        "Content-Type": "image/png",
+        "Content-Disposition": 'attachment; filename="marble.png"',
+      },
+    });
+  }
+}
+
+export default MarbleImage;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,22 @@ import { z } from "zod";
 export type AppContext = Context<{ Bindings: Env }>;
 
 export const Task = z.object({
-	name: Str({ example: "lorem" }),
-	slug: Str(),
-	description: Str({ required: false }),
-	completed: z.boolean().default(false),
-	due_date: DateTime(),
+        name: Str({ example: "lorem" }),
+        slug: Str(),
+        description: Str({ required: false }),
+        completed: z.boolean().default(false),
+        due_date: DateTime(),
 });
+
+export const ColorPreset = z
+  .enum(["blue", "red", "green", "purple"])
+  .default("blue");
+
+export const MarbleQuery = z.object({
+  color: ColorPreset,
+  datetime: DateTime().optional(),
+  username: Str({ required: false }),
+  size: z.enum(["16:9", "9:16", "1:1"]).default("1:1"),
+});
+
+export type MarbleQuery = z.infer<typeof MarbleQuery>;


### PR DESCRIPTION
## Summary
- add `pureimage` dependency
- define marble image query types
- implement `/api/marbleImage` endpoint generating PNGs from seed and color preset

## Testing
- `npx tsc -p tsconfig.json`
- `pnpm run test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_68b2efe7476c8331bd8f05011389b9d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an image generation endpoint that produces downloadable marble-pattern PNGs.
  * Supports color presets (blue, red, green, purple) and size options (16:9, 9:16, 1:1).
  * Optional username and datetime inputs can create consistent, repeatable images.

* **Chores**
  * Added a new image rendering library dependency to enable PNG generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->