### PR TITLE
feat: add marble image generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@types/node": "22.13.0",
     "@types/service-worker-mock": "^2.0.4",
+    "typescript": "^5.9.2",
     "wrangler": "^4.33.1"
   },
   "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@types/service-worker-mock':
         specifier: ^2.0.4
         version: 2.0.4
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
       wrangler:
         specifier: ^4.33.1
         version: 4.33.1(@cloudflare/workers-types@4.20250830.0)
@@ -502,6 +505,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
@@ -943,6 +951,8 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  typescript@5.9.2: {}
 
   ufo@1.6.1: {}
 

--- a/src/endpoints/marbleImage.ts
+++ b/src/endpoints/marbleImage.ts
@@ -1,0 +1,99 @@
+import { OpenAPIRoute } from "chanfana";
+import { AppContext, MarbleQuery, ColorPreset } from "../types";
+import { z } from "zod";
+// We generate a simple SVG image instead of relying on Node canvas APIs
+// so that the endpoint can run in a Cloudflare Worker environment.
+
+const colorPresets: Record<z.infer<typeof ColorPreset>, string[]> = {
+  blue: ["#1e3a8a", "#3b82f6", "#93c5fd"],
+  red: ["#7f1d1d", "#ef4444", "#fca5a5"],
+  green: ["#064e3b", "#10b981", "#6ee7b7"],
+  purple: ["#581c87", "#a855f7", "#d8b4fe"],
+};
+
+function xmur3(str: string) {
+  let h = 1779033703 ^ str.length;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(h ^ str.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return function () {
+    h = Math.imul(h ^ (h >>> 16), 2246822507);
+    h = Math.imul(h ^ (h >>> 13), 3266489909);
+    return (h ^= h >>> 16) >>> 0;
+  };
+}
+
+function mulberry32(a: number) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function getDimensions(size: string) {
+  switch (size) {
+    case "16:9":
+      return { width: 1600, height: 900 };
+    case "9:16":
+      return { width: 900, height: 1600 };
+    default:
+      return { width: 1000, height: 1000 };
+  }
+}
+
+export class MarbleImage extends OpenAPIRoute {
+  schema = {
+    summary: "Generate a marble pattern image",
+    request: {
+      query: MarbleQuery,
+    },
+    responses: {
+      200: {
+        description: "SVG marble image",
+        content: {
+          "image/svg+xml": {
+            schema: {
+              type: "string",
+              format: "binary",
+            },
+          },
+        },
+      },
+    },
+  } as const;
+
+  async handle(c: AppContext) {
+    const { query } = await this.getValidatedData<typeof this.schema>();
+    const { color, datetime, username, size } = query;
+
+    const ts = datetime ? new Date(datetime).getTime() : Date.now();
+    const seedStr = `${username ?? ""}${ts}`;
+    const seed = xmur3(seedStr)();
+    const rand = mulberry32(seed);
+
+    const { width, height } = getDimensions(size);
+    const palette = colorPresets[color];
+
+    let shapes = "";
+    for (let i = 0; i < 800; i++) {
+      const fill = palette[Math.floor(rand() * palette.length)];
+      const x = rand() * width;
+      const y = rand() * height;
+      const r = rand() * Math.min(width, height) * 0.1;
+      shapes += `<circle cx="${x.toFixed(2)}" cy="${y.toFixed(2)}" r="${r.toFixed(2)}" fill="${fill}" fill-opacity="0.5" />`;
+    }
+
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}"><rect width="100%" height="100%" fill="#ffffff"/>${shapes}</svg>`;
+    return new Response(svg, {
+      headers: {
+        "Content-Type": "image/svg+xml",
+        "Content-Disposition": 'attachment; filename="marble.svg"',
+      },
+    });
+  }
+}
+
+export default MarbleImage;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,22 @@ import { z } from "zod";
 export type AppContext = Context<{ Bindings: Env }>;
 
 export const Task = z.object({
-	name: Str({ example: "lorem" }),
-	slug: Str(),
-	description: Str({ required: false }),
-	completed: z.boolean().default(false),
-	due_date: DateTime(),
+        name: Str({ example: "lorem" }),
+        slug: Str(),
+        description: Str({ required: false }),
+        completed: z.boolean().default(false),
+        due_date: DateTime(),
 });
+
+export const ColorPreset = z
+  .enum(["blue", "red", "green", "purple"])
+  .default("blue");
+
+export const MarbleQuery = z.object({
+  color: ColorPreset,
+  datetime: DateTime().optional(),
+  username: Str({ required: false }),
+  size: z.enum(["16:9", "9:16", "1:1"]).default("1:1"),
+});
+
+export type MarbleQuery = z.infer<typeof MarbleQuery>;


### PR DESCRIPTION
## Summary
- serve marble patterns as SVG instead of using Node canvas so Workers can deploy
- seed patterns with optional datetime and username, supporting color presets and fixed aspect ratios
- add TypeScript dev dependency

## Testing
- `pnpm exec tsc -p tsconfig.json`
- `pnpm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b2efe7476c8331bd8f05011389b9d8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Marble image endpoint now returns scalable SVG instead of PNG, improving clarity at any size and often reducing file size. Response headers updated and downloads as marble.svg. Background set to white. Request parameters unchanged and deterministic visuals preserved.

- Chores
  - Added TypeScript to development dependencies to support type-checked development workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->